### PR TITLE
Add cue point for first .wav file

### DIFF
--- a/cuecat.js
+++ b/cuecat.js
@@ -40,9 +40,7 @@ const cuecat = (files, bitDepth='16', sampleRate=44100.0) => {
     // set cue points (not regions)
     offset = 0
     chunks.forEach(chunk => {
-        if (offset > 0) {
-            wav.setCuePoint({position: offset / sampleRate * 1000}) // milliseconds
-        }
+        wav.setCuePoint({position: offset / sampleRate * 1000}) // milliseconds
         offset += chunk[0].length
     })
     return wav


### PR DESCRIPTION
Previously, the cue points created with `cuecat` didn't include the 
first .wav file (at offset 0), with the result that `SLI00` on the M8
started from the second sample.  This patch fixes the issue by 
including a cue point at offset 0.